### PR TITLE
adding initial Gemfile to avoid chicken-egg errors when running 'rails new …'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+# This is a skeleton Gemfile to be checked out locally for the initial `rails new ...` command to proceed.
+# Please enter 'Y' when prompted to Overwrite this file.
+
+source 'https://rubygems.org'
+  
+gem 'bundler', '~> 1.17'
+
+gem 'rails', '~> 5.2'
+

--- a/README.md
+++ b/README.md
@@ -8,14 +8,19 @@ This repository holds the Rails application template referred to in our [kickoff
 
 - [ ] Create a directory for your rails app and move into it
 
+- [ ] Copy the `Gemfile` in this template project to your rails app directory
+
 - [ ] Run the following commands:
 
   (Note that you may also use `--webpack=react` or `--webpack=stimulus` during the rails new command if you already know you will be using one of these frameworks)
 
 ```bash
 gem install rails --no-document
+
 gem update bundler
+
 rails new . -T --skip-coffee --webpack --database=postgresql -m https://raw.githubusercontent.com/TanookiLabs/tanooki-rails-template/master/rails-kickoff-template.rb
+# When prompted to `overwrite Gemfile ?`, press 'Y' and continue
 ```
 
 - [ ] Clean up your Gemfile


### PR DESCRIPTION
Following these instructions, I get this error when trying to run the `rails new ...` command:
`Could not locate Gemfile or .bundle/ directory`

I thought this may be a ruby 2.6 issue (bundler is now baked in) but tried on 2.5.3 and saw the same thing.

I think we still need to have a skeleton `Gemfile` to start off with.