### PR TITLE
Fix webpacker setup

### DIFF
--- a/rails-kickoff-template.rb
+++ b/rails-kickoff-template.rb
@@ -142,6 +142,7 @@ def output_final_instructions
       4) Setup Redis (if using Sidekiq)
       5) Review your README.md file for needed updates
       6) Review your Gemfile for formatting
+      7) If you ran the install command with webpack=react, you also need to run: rake webpacker:install:react
     MSG
 
     say msg, :magenta

--- a/rails-kickoff-template.rb
+++ b/rails-kickoff-template.rb
@@ -426,6 +426,5 @@ end
 run_template!
 
 if no?("Is this a new application?")
-  $skip_webpacker_install = true
   run_after_bundle_callbacks
 end

--- a/rails-kickoff-template.rb
+++ b/rails-kickoff-template.rb
@@ -415,14 +415,17 @@ def setup_generators
 end
 
 def setup_webpacker
-  if yes?("Setup webpacker? (skip this if you removed --webpack)")
-    bundle_command "exec rails webpacker:install"
-    git_proxy_commit "Initialized webpacker"
+  after_bundle do
+    if yes?("Setup webpacker? (skip this if you removed --webpack)")
+      bundle_command "exec rails webpacker:install"
+      git_proxy_commit "Initialized webpacker"
+    end
   end
 end
 
 run_template!
 
 if no?("Is this a new application?")
+  $skip_webpacker_install = true
   run_after_bundle_callbacks
 end


### PR DESCRIPTION
Running ` bundle_command "exec rails webpacker:install"` requires bundle to have already run, so this fixes it.

Reported here: https://tanookilabs.slack.com/archives/C1T5U3DKK/p1554150745055600