### PR TITLE
Only install overcommit in development group

### DIFF
--- a/rails-kickoff-template.rb
+++ b/rails-kickoff-template.rb
@@ -175,10 +175,12 @@ def setup_sidekiq
 end
 
 def setup_linters
-  gem "rubocop", require: false
-  gem "rubocop-rspec", require: false
-  gem "rubocop-thread_safety", require: false
-  gem "overcommit"
+  gem_group :development do
+    gem "rubocop", require: false
+    gem "rubocop-rspec", require: false
+    gem "rubocop-thread_safety", require: false
+    gem "overcommit"
+  end
 
   after_bundle do
     get "#{REPOSITORY_PATH}/.rubocop.yml", ".rubocop.yml"


### PR DESCRIPTION
this ends up with a few development groups 🤷🏻‍♂️

<details>
  <summary>example Gemfile from tests</summary>

```
source 'https://rubygems.org'
git_source(:github) { |repo| "https://github.com/#{repo}.git" }

ruby '2.6.1'

# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
gem 'rails', '~> 5.2.3'
# Use postgresql as the database for Active Record
gem 'pg', '>= 0.18', '< 2.0'
# Use Puma as the app server
gem 'puma', '~> 3.11'
# Use SCSS for stylesheets
gem 'sass-rails', '~> 5.0'
# Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
gem 'webpacker'
# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
gem 'jbuilder', '~> 2.5'
# Use ActiveModel has_secure_password
# gem 'bcrypt', '~> 3.1.7'

# Use Capistrano for deployment
# gem 'capistrano-rails', group: :development

# Reduces boot times through caching; required in config/boot.rb
gem 'bootsnap', '>= 1.1.0', require: false

group :development, :test do
  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
end

group :development do
  # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
  gem 'web-console', '>= 3.3.0'
  gem 'listen', '>= 3.0.5', '< 3.2'
  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
  gem 'spring'
  gem 'spring-watcher-listen', '~> 2.0.0'
end


# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

gem 'sidekiq'
gem 'mta-settings'
gem 'haml-rails'
gem 'sentry-raven'
gem 'skylight'
group :production do
  gem 'rack-timeout'
end

group :development, :test do
  gem 'rspec-rails'
  gem 'factory_bot_rails'
  gem 'dotenv-rails'
  gem 'pry-rails'
end

group :development do
  gem 'bullet'
end

group :test do
  gem 'capybara'
  gem 'capybara-selenium'
end

group :development do
  gem 'rubocop', require: false
  gem 'rubocop-rspec', require: false
  gem 'rubocop-thread_safety', require: false
  gem 'overcommit'
end

```
</summary>