### PR TITLE
Exclude describe cop for lint_spec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -75,3 +75,7 @@ Style/StringLiterals:
 
 Style/StringLiteralsInInterpolation:
   Enabled: false
+
+RSpec/DescribeClass:
+  Exclude:
+    - spec/lint_spec.rb


### PR DESCRIPTION
### Overview

* Fixes rubocop error I encountered from a recent install with the latest template:

```
Offenses:

spec/lint_spec.rb:5:16: C: RSpec/DescribeClass: The first argument to describe should be the class or module being tested.
RSpec.describe "Factories" do
               ^^^^^^^^^^^

14 files inspected, 1 offense detected
```