### PR TITLE
Default to log_level :info in production

### DIFF
--- a/rails-kickoff-template.rb
+++ b/rails-kickoff-template.rb
@@ -126,7 +126,7 @@ def setup_environments
 
   ["development", "test"].each do |env|
     inject_into_file "config/environments/#{env}.rb", before: /^end\n/ do
-      "  config.action_controller.action_on_unpermitted_parameters = :raise\n"
+      "\n  config.action_controller.action_on_unpermitted_parameters = :raise\n"
     end
   end
   git_proxy_commit "Raise an error when unpermitted parameters in development"


### PR DESCRIPTION
- allow this to be configured via LOG_LEVEL env var
- cleanup bullet config
- raise on unpermitted parameters by default in dev, instead of silently
  dropping them
- ~setup lograge, and log parameters, user id, user email~

fixes #19 
