### PR TITLE
Generate factory filenames like users_factory.rb

### DIFF
--- a/rails-kickoff-template.rb
+++ b/rails-kickoff-template.rb
@@ -474,6 +474,7 @@ def setup_generators
       g.helper false
 
       g.fixture_replacement :factory_bot, dir: "spec/factories"
+      g.factory_bot suffix: "factory"
     end
   EOF
 


### PR DESCRIPTION
instead of users.rb, making it easier on the brain to look at fuzzy-finder results