### PR TITLE
Remove pry-rails and bullet

### DIFF
--- a/rails-kickoff-template.rb
+++ b/rails-kickoff-template.rb
@@ -89,11 +89,9 @@ def add_gems
     gem "rspec_tap", require: false
     gem "factory_bot_rails"
     gem "dotenv-rails"
-    gem "pry-rails"
   end
 
   gem_group :development do
-    gem "bullet"
     gem "letter_opener"
   end
 
@@ -114,17 +112,6 @@ def setup_haml
 end
 
 def setup_environments
-  inject_into_file "config/environments/development.rb", before: /^end\n/ do
-    <<-RB
-  config.after_initialize do
-    # https://github.com/flyerhzm/bullet#configuration
-    Bullet.enable = true
-    Bullet.rails_logger = true
-  end
-    RB
-  end
-  git_proxy_commit "Configure Bullet in development"
-
   inject_into_file "config/environments/development.rb", before: /^end\n/ do
     <<-RB
   config.action_mailer.delivery_method = :letter_opener


### PR DESCRIPTION
pry doesn't play well with ruby 2.7

    % bundle exec rails c
    Running via Spring preloader in process 53406
    Loading development environment (Rails 6.0.2.2)
    <main>:1: warning: __FILE__ in eval may not return location in binding; use Binding#source_location instead
    /Users/bkroeker/.gem/ruby/2.7.0/gems/pry-0.12.2/lib/pry/commands/whereami.rb:40: warning: in `eval'
    <main>:1: warning: __LINE__ in eval may not return location in binding; use Binding#source_location instead
    /Users/bkroeker/.gem/ruby/2.7.0/gems/pry-0.12.2/lib/pry/commands/whereami.rb:41: warning: in `eval'
    [1] pry(main)>

bullet can be annoying